### PR TITLE
QA fixes observed by Rick Lisseveld

### DIFF
--- a/FHIR-us-ndh.xml
+++ b/FHIR-us-ndh.xml
@@ -153,7 +153,7 @@
 <artifact deprecated="true" id="ValueSet/LanguageProficiencyVS" key="ValueSet-LanguageProficiencyVS" name="Language Proficiency Value Set"/>
 <artifact id="SearchParameter/location-accessibility" key="SearchParameter-location-accessibility" name="Location accessibility"/>
 <artifact id="SearchParameter/location-contains" key="SearchParameter-location-contains" name="Location contains"/>
-<artifact id="SearchParameter/location-new-patient" key="SearchParameter-location-new-patient" name="Location new-patient"/>
+<artifact deprecated="true" id="SearchParameter/location-new-patient" key="SearchParameter-location-new-patient" name="Location new-patient"/>
 <artifact deprecated="true" id="SearchParameter/location-new-patient-and-from-network" key="SearchParameter-location-new-patient-and-from-network" name="Location new-patient-and-from-network"/>
 <artifact deprecated="true" id="SearchParameter/location-new-patient-from-network" key="SearchParameter-location-new-patient-from-network" name="Location new-patient-from-network"/>
 <artifact deprecated="true" id="SearchParameter/location-verification-status" key="SearchParameter-location-verification-status" name="Location verification-status"/>

--- a/Requirements-fromNarrative.json
+++ b/Requirements-fromNarrative.json
@@ -1,7 +1,7 @@
 {
   "resourceType" : "Requirements",
   "id" : "fromNarrative",
-  "url" : "http://hl7.org/fhir/us/davinci-cdex/Requirements/fromNarrative",
+  "url" : "http://hl7.org/fhir/us/ndh/Requirements/fromNarrative",
   "name" : "FromNarrative",
   "title" : "Narrative Conformance Statements",
   "status" : "active",

--- a/input/fsh/Base-SearchPrameters.fsh
+++ b/input/fsh/Base-SearchPrameters.fsh
@@ -643,22 +643,6 @@ Title: "Location contains"
 * multipleOr = true
 * multipleAnd = true
 
-Instance: location-new-patient
-InstanceOf: SearchParameter
-Usage: #definition
-Title: "Location new-patient"
-* status = #active
-* code = #new-patient
-* name = "LocationNewPatientSearchParameter"
-* description = "Select Locations of the specified new-patient"
-* url = "http://hl7.org/fhir/us/ndh/SearchParameter/location-new-patient"
-* base[0] = #Location
-* type = #token
-* expression = "Location.extension.where(url='http://hl7.org/fhir/us/ndh/StructureDefinition/base-ext-newpatients').extension.where(url ='acceptingPatients').value.ofType(CodeableConcept)"
-//* xpath = "f:Location/f:extension[@url='http://hl7.org/fhir/us/ndh/StructureDefinition/base-ext-newpatients']/f:extension[@url ='acceptingPatients']/f:valueCodeableConcept/f:coding/f:code/@value"
-* xpathUsage = #normal
-* multipleAnd = true
-* multipleOr = true
 
 
 

--- a/input/fsh/Base-SearchPrameters.fsh
+++ b/input/fsh/Base-SearchPrameters.fsh
@@ -659,28 +659,7 @@ Title: "Location new-patient"
 * multipleAnd = true
 * multipleOr = true
 
-/*
-Instance: location-new-patient-from-network
-InstanceOf: SearchParameter
-Usage: #definition
-Title: "Location new-patient-from-network"
-* status = #active
-* code = #new-patient-from-network
-* name = "LocationNewPatientFromNetworkSearchParameter"
-* description = "Select Locations of the specified new-patient-from-network"
-* url = "http://hl7.org/fhir/us/ndh/SearchParameter/location-new-patient-from-network"
-* base[0] = #Location
-* type = #reference
-* target[0] = #Organization
-* expression = "Location.extension.where(url='http://hl7.org/fhir/us/ndh/StructureDefinition/base-ext-newpatients').extension.where(url='fromNetwork').value.ofType(Reference)"
-//* xpath = "f:Location/f:extension[@url='http://hl7.org/fhir/us/ndh/StructureDefinition/base-ext-newpatients']/f:extension[@url='fromNetwork']/f:valueReference/f:reference/@value"
-* xpathUsage = #normal
-* multipleAnd = true
-* multipleOr = true
-* chain[0] = #identifier
-* chain[+] = #name
-* chain[+] = #partof
-*/
+
 
 
 

--- a/input/fsh/Base-SearchPrameters.fsh
+++ b/input/fsh/Base-SearchPrameters.fsh
@@ -87,6 +87,7 @@ Title: "verification-status"
 * base[+] = #PractitionerRole
 * base[+] = #InsurancePlan
 * base[+] = #OrganizationAffiliation
+* base[+] = #Group
 * type = #token
 * expression = "extension('http://hl7.org/fhir/us/ndh/StructureDefinition/base-ext-verification-status').value"
 * xpathUsage = #normal

--- a/input/fsh/Base-SearchPrameters.fsh
+++ b/input/fsh/Base-SearchPrameters.fsh
@@ -603,7 +603,6 @@ Title: "InsurancePlan plan-type"
 * multipleAnd = true
 * modifier[0] = #text
 
-
 //-------------------------------------------
 // Location
 //-------------------------------------------    

--- a/input/fsh/Ndh-CapabilityStatement.fsh
+++ b/input/fsh/Ndh-CapabilityStatement.fsh
@@ -465,13 +465,14 @@ from this list to access necessary data based on their local use cases and other
     * insert Interaction(#search-type, #SHOULD, "Search all resources of the specified type based on some filter criteria.")
     * insert Interaction(#vread, #SHOULD, "Read the state of specific version of the resource")
     * insert Interaction(#history-instance, #SHOULD, "Retrieve the history of the resource")
-    * insert Interaction(#history-type, #SHOULD, "Retrieve the history of the resource type")
+    * insert Interaction(#history-type, #MAY, "Retrieve the history of the resource type")
     * versioning = #versioned
     * referencePolicy[+] = #literal
     * referencePolicy[+] = #local
 
 //    * insert SearchParamNdh("location", group-location, #reference, #SHALL,"The location of the Group")
 //    * insert SearchParamNdh("endpoint", group-endpoint, #reference, #SHALL, "Group endpoint")
+    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"Endpoint verification status")
 
     * insert SearchParam("member", Group-member, #reference, #SHOULD, "Group member")
     * insert SearchParam("managing-entity", Group-managing-entity, #reference, #SHOULD, "Group managing entity")

--- a/input/fsh/Ndh-CapabilityStatement.fsh
+++ b/input/fsh/Ndh-CapabilityStatement.fsh
@@ -470,9 +470,7 @@ from this list to access necessary data based on their local use cases and other
     * referencePolicy[+] = #literal
     * referencePolicy[+] = #local
 
-//    * insert SearchParamNdh("location", group-location, #reference, #SHALL,"The location of the Group")
-//    * insert SearchParamNdh("endpoint", group-endpoint, #reference, #SHALL, "Group endpoint")
-    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"Endpoint verification status")
+    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"Group verification status")
 
     * insert SearchParam("member", Group-member, #reference, #SHOULD, "Group member")
     * insert SearchParam("managing-entity", Group-managing-entity, #reference, #SHOULD, "Group managing entity")

--- a/input/fsh/Ndh-CapabilityStatement.fsh
+++ b/input/fsh/Ndh-CapabilityStatement.fsh
@@ -470,7 +470,7 @@ from this list to access necessary data based on their local use cases and other
     * referencePolicy[+] = #literal
     * referencePolicy[+] = #local
 
-    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"Group verification status")
+    * insert SearchParamNdh("verification-status", verification-status, #token, #SHOULD,"Group verification status")
 
     * insert SearchParam("member", Group-member, #reference, #SHOULD, "Group member")
     * insert SearchParam("managing-entity", Group-managing-entity, #reference, #SHOULD, "Group managing entity")

--- a/input/fsh/Ndh-CapabilityStatement.fsh
+++ b/input/fsh/Ndh-CapabilityStatement.fsh
@@ -46,7 +46,7 @@ from this list to access necessary data based on their local use cases and other
     * insert SearchParamNdh("dynamic-registration-trust-profile", endpoint-dynamic-registration-trust-profile, #token, #SHALL,"Endpoint dynamic registration trust profile")
     * insert SearchParamNdh("access-control-mechanism", endpoint-access-control-mechanism, #token, #SHALL,"Endpoint access control mechanism")
     * insert SearchParamNdh("ihe-connection-type", endpoint-ihe-connection-type, #token, #SHALL,"Endpoint ihe connection type")
-    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"Endpoint verification status")
+    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"verification status")
 
     * insert SearchParam("connection-type", Endpoint-connection-type, #token, #SHALL,"Connection type")
     * insert SearchParam("identifier", Endpoint-identifier, #token, #SHALL,"Endpoint identifier")
@@ -85,7 +85,7 @@ from this list to access necessary data based on their local use cases and other
     * insert SearchParamNdh("new-patient-from-network", healthcareservice-new-patient-from-network, #reference, #SHALL,"New patient from network")
     * insert SearchParamNdh("eligibility", healthcareservice-eligibility, #token, #SHALL,"Eligibility")
     * insert SearchParamNdh("new-patient", healthcareservice-new-patient, #token, #SHALL,"New patient")
-    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"Verification status")
+    * insert SearchParamNdh("verification-status", verification-status, #token, #SHALL,"verification status")
     * insert SearchParamNdh("location", healthcareservice-location, #reference, #SHALL,"The location of the Healthcare Service")
     * insert SearchParamNdh("organization", healthcareservice-organization, #reference, #SHALL,"The organization that provides this Healthcare Service")
 
@@ -470,7 +470,7 @@ from this list to access necessary data based on their local use cases and other
     * referencePolicy[+] = #literal
     * referencePolicy[+] = #local
 
-    * insert SearchParamNdh("verification-status", verification-status, #token, #SHOULD,"Group verification status")
+    * insert SearchParamNdh("verification-status", verification-status, #token, #SHOULD,"Verification status")
 
     * insert SearchParam("member", Group-member, #reference, #SHOULD, "Group member")
     * insert SearchParam("managing-entity", Group-managing-entity, #reference, #SHOULD, "Group managing entity")

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -97,7 +97,6 @@
 
 [location-accessibility]: SearchParameter-location-accessibility.html
 [location-contains]: SearchParameter-location-contains.html
-[location-new-patient]: SearchParameter-location-new-patient.html
 
 
 [network-coverage-area]: SearchParameter-network-coverage-area.html

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -98,7 +98,7 @@
 [location-accessibility]: SearchParameter-location-accessibility.html
 [location-contains]: SearchParameter-location-contains.html
 [location-new-patient]: SearchParameter-location-new-patient.html
-[location-new-patient-from-network]: SearchParameter-location-new-patient-from-network.html
+
 
 [network-coverage-area]: SearchParameter-network-coverage-area.html
 

--- a/input/intro-notes/StructureDefinition-ndh-Location-notes.md
+++ b/input/intro-notes/StructureDefinition-ndh-Location-notes.md
@@ -47,7 +47,6 @@ Since there is no direct individual url for each Search Parameter defined by FHI
 | **_include** | **Example** |
 |--------------|-------------|
 | Location:endpoint |`GET [base]/Location?_include=Location:endpoint` |
-| Location:new-patient-from-network |`GET [base]/Location?_include=Location:new-patient-from-network` |
 | Location:organization |`GET [base]/Location?_include=Location:organization` |
 | Location:partof |`GET [base]/Location?_include=Location:partof` |
 

--- a/input/intro-notes/StructureDefinition-ndh-Location-notes.md
+++ b/input/intro-notes/StructureDefinition-ndh-Location-notes.md
@@ -9,7 +9,6 @@
 |---------------------------|----------|-------------|
 | [accessibility](SearchParameter-location-accessibility.html) | token | `GET [base]/Location?accessibility=cultcomp`|
 | [contains](SearchParameter-location-contains.html) | special |`GET [base]/Location?contains=41.809006\|-71.41177`|
-| [new-patient](SearchParameter-location-new-patient.html) | token |`GET [base]/Location?=new-patient=newpt` |
 | [verification-status](SearchParameter-verification-status.html) | token | `GET [base]/Location?verification-status=complete` |
 
 	

--- a/input/intro-notes/StructureDefinition-ndh-Network-notes.md
+++ b/input/intro-notes/StructureDefinition-ndh-Network-notes.md
@@ -68,7 +68,6 @@ Since there is no direct individual url for each Search Parameter defined by FHI
 | InsurancePlan:coverage-network |`GET [base]/Organization?type=ntwk&_revinclude=InsurancePlan:coverage-network` |
 | InsurancePlan:plan-network |`GET [base]/Organization?type=ntwk&_revinclude=InsurancePlan:plan-network` |
 | InsurancePlan:network |`GET [base]/Organization?type=ntwk&_revinclude=InsurancePlan:network` |
-| Location:new-patient-from-network |`GET [base]/Organization?type=ntwk&_revinclude=Location:new-patient-from-network` |
 | OrganizationAffiliation:network |`GET [base]/Organization?type=ntwk&_revinclude=OrganizationAffiliation:network` |
 | PractitionerRole:network |`GET [base]/Organization?type=ntwk&_revinclude=PractitionerRole:network` |
 | PractitionerRole:new-patient-from-network |`GET [base]/Organization?type=ntwk&_revinclude=PractitionerRole:new-patient-from-network` |

--- a/input/pagecontent/base-artifacts.md
+++ b/input/pagecontent/base-artifacts.md
@@ -43,7 +43,7 @@ Extension/Profile|[Directory Endpoint]|[Directory HealthcareService]|[Directory 
 *[NDH Location Reference]*                       |     |     |     |     | Yes |     |     |     |     | Yes
 *[NDH Logo]*                                     |     | Yes |     |     |     | Yes | Yes |     |     
 *[NDH Network Reference]*                        |     | Yes |     |     |     |     |     |     | Yes  
-*[NDH NewPatients]*                              |     | Yes |     | Yes |     |     |     |     | Yes  
+*[NDH NewPatients]*                              |     | Yes |     |     |     |     |     |     | Yes  
 *[NDH Orginization Alias Period]*                |     |     |     |     |     | Yes |     |     |     
 *[NDH Organization Alias Type]*                  |     |     |     |     |     | Yes |     |     |     
 *[NDH Org Description]*                          |     |     |     |     |     | Yes |     |     |     


### PR DESCRIPTION
Rick Lisseveld: I took a look at the build of the CI IG from 3-23 today. SearchParameter-location-new-patient-and-from-network is gone from the Location Profile page, however, it is still listed as an _include. https://build.fhir.org/ig/HL7/fhir-us-ndh/StructureDefinition-ndh-Location.html#_include-search-parameter
I am not sure if it was intended or not, but the [SearchParameter-location-new-patient](https://build.fhir.org/ig/HL7/fhir-us-ndh/SearchParameter-location-new-patient.html) was also removed from the Capability Statement, but it is showing on the Profile page.Rick Lisseveld: On a separate note: 
Group was added for [FHIR-52875](http://jira.hl7.org/browse/FHIR-52875) with the history-type set to SHOULD instead of MAY as decided for all resource/profiles in [FHIR-53380](http://jira.hl7.org/browse/FHIR-53380). https://build.fhir.org/ig/HL7/fhir-us-ndh/branches/USrealmConnectathon202603/CapabilityStatement-ndh-server.html#Group1-10 and https://build.fhir.org/ig/HL7/fhir-us-ndh/CapabilityStatement-ndh-server.html#Group1-10
I am thinking it is a copy/paste error and not intended, but thought I would ask before opening a Jira.
Also,  the CapabilityStatement entry for Group does not contain the search parameter verification-status, but CareTeam, the resource it replaced, had verification-status.
The ndh-Group profile contains the extension for verification-status so it could be searched using the verification-result search parameter if Group were added to the list of base Resources. I am not sure if it is relevant or not to have a Group verified.  Let me know if I should open a Jira for this question.